### PR TITLE
Replace .umd.cjs with standalone compiled version

### DIFF
--- a/EuroClimateCheck/vite.config.js
+++ b/EuroClimateCheck/vite.config.js
@@ -16,14 +16,13 @@ export default defineConfig({
     lib: {
       entry: 'src/main.js',
       name: 'EuroClimateCheck',
-      fileName: 'euroclimatecheck'
+      fileName: 'euroclimatecheck',
+      formats: ['iife']
     },
     rollupOptions: {
-      external: ['vue'],
       output: {
-        globals: {
-          vue: 'Vue'
-        }
+        format: 'iife',
+        entryFileNames: 'euroclimatecheck.js'
       }
     }
   },

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -12,26 +12,16 @@ function euroclimatecheck_admin_style() {
 	wp_register_style( 'euroclimatecheck_admin_css', EUROCLIMATECHECK_PLUGIN_URL . '/EuroClimateCheck/dist/euroclimatecheck.css', false, $plugin_data['Version'] );
 	wp_enqueue_style( 'euroclimatecheck_admin_css' );
 
-	// First register Vue from CDN
-	wp_register_script(
-		'vue',
-		'https://unpkg.com/vue@3/dist/vue.global.js',
-		array(),
-		'3.5.13',
-		true
-	);
-
-	// Register the built Vue component
+	// Register the standalone Vue component (includes all dependencies)
 	wp_register_script(
 		'euroclimatecheck_vue_component',
-		EUROCLIMATECHECK_PLUGIN_URL . '/EuroClimateCheck/dist/euroclimatecheck.umd.cjs', // Update path to built file
-		array('vue'),
+		EUROCLIMATECHECK_PLUGIN_URL . '/EuroClimateCheck/dist/euroclimatecheck.js',
+		array(),
 		'1.0.0',
 		true
 	);
 
-	// Enqueue both scripts
-	wp_enqueue_script('vue');
+	// Enqueue the standalone script
 	wp_enqueue_script('euroclimatecheck_vue_component');
 
 	wp_register_style( 'euroclimatecheck_fontawesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css' );


### PR DESCRIPTION
Fixes #1

## Summary
- Modified Vite configuration to create standalone IIFE build with .js extension
- Updated WordPress enqueue logic to use single file without external Vue dependency
- Eliminates MIME type issues where servers serve .umd.cjs as text/plain

## Test plan
- [ ] Run `pnpm build` in EuroClimateCheck directory
- [ ] Verify euroclimatecheck.js is generated in dist/
- [ ] Test WordPress plugin functionality works without external dependencies
- [ ] Confirm no console errors in browser

Generated with [Claude Code](https://claude.ai/code)